### PR TITLE
Implement more informative error

### DIFF
--- a/pytak/classes.py
+++ b/pytak/classes.py
@@ -82,8 +82,7 @@ class Worker:  # pylint: disable=too-few-public-methods
 
     async def handle_data(self, data: bytes) -> None:
         """Handle data (placeholder method, please override)."""
-        del data
-        self._logger.warning("Override this method!")
+        raise NotImplementedError("Subclasses need to override this method")
 
     async def run(self, number_of_iterations=-1):
         """Run this Thread, reads Data from Queue & passes data to next Handler."""


### PR DESCRIPTION
**What does this PR implement?**
Implements a more informative error message. Instead of "please override this method", a traceback is raised to the exact function/file/line.